### PR TITLE
Fixed chip_id command in Focus library

### DIFF
--- a/libraries/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/libraries/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -122,6 +122,11 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
     }
   }
 
+  if (strcmp_P(command + 9, PSTR("chip_id")) == 0) {
+    ::Focus.send(Runtime.device().settings.getChipID());
+    return EventHandlerResult::EVENT_CONSUMED;
+  }
+
   return EventHandlerResult::OK;
 }
 


### PR DESCRIPTION
Added chip_id code in Focus library to respond to a "hardware." command properly.

- [x]  Respond to a hardware.chip_id call trough Focus API.